### PR TITLE
Standardise name as 'Poplus'

### DIFF
--- a/about.md
+++ b/about.md
@@ -5,7 +5,7 @@ title: About Poplus
 
 # What is Poplus?
 
-POPLUS is a community of activists, citizens and developers. Aiming to serve our wider community, we collaborate to create quality web services that are open (source), easy to use, setup and re-use. Our goals is to foster social change by empowering citizens and civil society groups with the use of web technology.
+Poplus is a community of activists, citizens and developers. Aiming to serve our wider community, we collaborate to create quality web services that are open (source), easy to use, setup and re-use. Our goals is to foster social change by empowering citizens and civil society groups with the use of web technology.
 
 ## Our Founding Principles
 
@@ -15,23 +15,23 @@ POPLUS is a community of activists, citizens and developers. Aiming to serve our
 
 ## Community
 
-There are three ways to participate in POPLUS: as Partners, Members, and Users.
+There are three ways to participate in Poplus: as Partners, Members, and Users.
 
 
 #### 1) Partners
 
-Are: The decision makers, strategists and the overall leaders of POPLUS.
+Are: The decision makers, strategists and the overall leaders of Poplus.
 
 They provide: resources to the project for the benefit of the wider community, helping to develop and grow the community through outreach, giving support on components that have been created for the wider community, and channelling information to specific interest groups about POPlus members that could be useful to them.
 
-They receive: 1. Reputational benefit both in the eyes of potential funders, governments, institutions and other NGOs; 2. support in the development and deployment of their own projects technically, strategically and operationally; 3. the potential to receive funding to support projects powered by or linked to POPLUS; 4. access to the resources of created by other organisations and memberships to help grow your organisation; 5. potential to have wider impact on the open source community through the credibility of being a POPlus partner,
+They receive: 1. Reputational benefit both in the eyes of potential funders, governments, institutions and other NGOs; 2. support in the development and deployment of their own projects technically, strategically and operationally; 3. the potential to receive funding to support projects powered by or linked to Poplus; 4. access to the resources of created by other organisations and memberships to help grow your organisation; 5. potential to have wider impact on the open source community through the credibility of being a POPlus partner,
 
 I want to be a Partner!
 
 
 #### 2) Members 
 
-Are: Those who contribute resources to POPLUS based on their own needs [eg creating components or changes based on the things they need]. Members interact with the community, use the software and providing valuable feedback. 
+Are: Those who contribute resources to Poplus based on their own needs [eg creating components or changes based on the things they need]. Members interact with the community, use the software and providing valuable feedback. 
 
 Receive: The kudos of being a part of something that is helping to change and shape societies, support from partners and the community for all components, credible and respected components with a good reputation, and Potential for funding from donors to create resources to contribute to the community.
 
@@ -40,17 +40,17 @@ I want to be a member!
 
 ####  3) User 
 
-Are: Those who don’t need to contribute anything towards POPLUS, and thus, do not have the responsibility of participating in the direction of the organisation.
+Are: Those who don’t need to contribute anything towards Poplus, and thus, do not have the responsibility of participating in the direction of the organisation.
 
 Receive: Free open source software that is regularly updated and easy to use.
 
-I want to use POPLUS!
+I want to use Poplus!
 
 
 ## Technology
 
 
-Our technological solution was born from the failure that our founding organisations faced in the implementation of new deployments of different applications in also different contexts (different countries, different cultures, different laws). Implementation of new websites and apps had become increasingly expensive, as each deployment required to 'reinvent the wheel' and re-write the code, adapting to each particular context. In order to avoid this problem, we took a more sustainable approach, which is to promote the development of websites from a component-based approach. This means that a websites must not be acknowledged as a whole, but as a group of different components that serve different and specific functionalities. In POPLUS we develop generic components based on Rest API's, so that future websites may choose to use one, two or several components, based on the functional needs that need to be satisfied.
+Our technological solution was born from the failure that our founding organisations faced in the implementation of new deployments of different applications in also different contexts (different countries, different cultures, different laws). Implementation of new websites and apps had become increasingly expensive, as each deployment required to 'reinvent the wheel' and re-write the code, adapting to each particular context. In order to avoid this problem, we took a more sustainable approach, which is to promote the development of websites from a component-based approach. This means that a websites must not be acknowledged as a whole, but as a group of different components that serve different and specific functionalities. In Poplus we develop generic components based on Rest API's, so that future websites may choose to use one, two or several components, based on the functional needs that need to be satisfied.
 
 Check out our [existing][catalogue] components!
 Check out the [list of components][developmentboard] we will build soon!
@@ -59,26 +59,26 @@ Check out the [list of components][developmentboard] we will build soon!
 ## Code of Honor
 
 
-POPLUS is a community and as such, its members and partners have mutual responsibilities. One of them is to respect our Code of Honor. This 'code' requires that each contributor to the component ecosystem will be responsible for taking care and securing technological support to the component each contributor has developed. Furthermore, whenever possible, POPLUS community members will provide assistance to other community members in order to facilitate the implementation of components into new websites.
+Poplus is a community and as such, its members and partners have mutual responsibilities. One of them is to respect our Code of Honor. This 'code' requires that each contributor to the component ecosystem will be responsible for taking care and securing technological support to the component each contributor has developed. Furthermore, whenever possible, Poplus community members will provide assistance to other community members in order to facilitate the implementation of components into new websites.
 
 
 
 ## How this Works.
 
 
-Any individual or organization can use and contribute to the PO+ ecosystem. Components are available in a community repository where new website developers can search to find and use the components they need for their own website, no matter if its for congress monitoring, using FOIA, or mapping public service delivery, developers are welcome to use the components that suits best their needs. In return, developers are encouraged to contribute with their own code and web innovations to further expand the PO+ ecosystem. In this sense, the PO+ developer community agrees to follow a set of basic rules and standards that may include code language, frameworks, and data tabulation for API’s or further semantic references. The key to the success of PO+ is getting the community to agree and follow common rules (which can change over time), so that we can make sure that no matter what component an individual or organization is developing, if it follows PO+, it means that such component will likely be interoperable with the other components of the PO+ ecosystem (though some adjustments may be required).
+Any individual or organization can use and contribute to the Poplus ecosystem. Components are available in a community repository where new website developers can search to find and use the components they need for their own website, no matter if its for congress monitoring, using FOIA, or mapping public service delivery, developers are welcome to use the components that suits best their needs. In return, developers are encouraged to contribute with their own code and web innovations to further expand the Poplus ecosystem. In this sense, the Poplus developer community agrees to follow a set of basic rules and standards that may include code language, frameworks, and data tabulation for API’s or further semantic references. The key to the success of Poplus is getting the community to agree and follow common rules (which can change over time), so that we can make sure that no matter what component an individual or organization is developing, if it follows Poplus, it means that such component will likely be interoperable with the other components of the Poplus ecosystem (though some adjustments may be required).
 
 
 ## The Objectives
 
 
-1. PO+ will reduce the cost and time of citizen driven tech efforts, encourage collective action and collaboration among users.
+1. Poplus will reduce the cost and time of citizen driven tech efforts, encourage collective action and collaboration among users.
 
-2. As a result of the latter, with POPLUS we expect to see more citizen driven tools during the first years of implementation, as well as more citizen-tech organizations that due to POPLUS can get easily up and running. 
+2. As a result of the latter, with Poplus we expect to see more citizen driven tools during the first years of implementation, as well as more citizen-tech organizations that due to Poplus can get easily up and running. 
 
-3. Due to the generic nature of POPLUS modules (using rest APIs), they should go beyond the perimeter of transparency and participation apps that originally motivated the development of these generic modules. Hence, POPLUS will also foster the development of apps for issues that are as diverse as extraction of natural resources, poverty, aid, public budgets, crisis management, etc.
+3. Due to the generic nature of Poplus modules (using rest APIs), they should go beyond the perimeter of transparency and participation apps that originally motivated the development of these generic modules. Hence, Poplus will also foster the development of apps for issues that are as diverse as extraction of natural resources, poverty, aid, public budgets, crisis management, etc.
 
-4. Because POPLUS provides the basic app infrastructure, we expect to see further innovation in citizen app development, which can expand on top of existing components (no need to spend time to get the basic infrastructure right). Thanks to a proper documentation, PO+ aims to achieve a positive learning curve among its community. 
+4. Because Poplus provides the basic app infrastructure, we expect to see further innovation in citizen app development, which can expand on top of existing components (no need to spend time to get the basic infrastructure right). Thanks to a proper documentation, Poplus aims to achieve a positive learning curve among its community. 
 
 5. To see tech collaboration in the development and use of generic modules is only the first stage of a broader effort that in future iterations could include collaboration in the policy and advocacy front. Hence, organizations that attempt to control corruption may not only develop transparency platforms based in common components, but they may also extend collaboration of accountability efforts from other non-tech grounds. For example, a corrupt organization that is legally based in the US., but which operates in Chile and has impact in Kenya, could eventually be hold accountable by coordinated organizations in each of the three countries. 
 


### PR DESCRIPTION
It’s distracting and confusing for the name to keep switching between
“Poplus”, “POPLUS”,  “POPlus”, and “PO+”. Standardise for now on “Poplus”.
