### PR TITLE
Adding represent-boundaries as a poplus component

### DIFF
--- a/_posts/2014-06-24-represent-boundaries.md
+++ b/_posts/2014-06-24-represent-boundaries.md
@@ -1,0 +1,14 @@
+---
+layout: components
+title:  "represent-boundaries"
+date:   2014-06-24 11:40:00
+categories: component
+owner: Open North
+component_url: http://represent.opennorth.ca/
+repo: https://github.com/rhymeswithcycle/represent-boundaries
+excerpt: A web service and an easy to include django app, that allows users to find what areas are covered by a given point.
+publish: true
+status: Alpha
+---
+
+A web service and an easy to include django app, that allows users to find what areas are covered by a given point.


### PR DESCRIPTION
[represent-boundaries](http://represent.opennorth.ca/) is now officially a poplus component.
