### PR TITLE
Create faqs

### DIFF
--- a/about/faqs
+++ b/about/faqs
@@ -1,0 +1,53 @@
+# New to Poplus? Read this first
+
+Greetings, and welcome to Poplus. Thanks for visiting!
+
+We know that it can be hard to understand exactly what Poplus is. Here are some hints about where to begin.
+
+## What should I do first?
+
+Here are five things that will start you off.
+
+1. Find out what Poplus is: visit our [About page](http://poplus.org/about/) and read our FAQs below.
+2. Understand what Poplus Components are: [see some Poplus Components in action](http://poplus.org/components/examples/).
+3. Take a look at the [Poplus map](http://poplus.org/get-involved/find-people/) and see if there’s anyone local to you. If so, they will be happy to say hello, or answer your questions.
+4. Join the [Google Group](https://groups.google.com/forum/#!forum/poplus) and introduce yourself. Poplus is open to anyone who is interested, and the Google Group is where most activity and discussion takes place. You are welcome, whether you are from an organisation which might like to use a Poplus Component, or a developer who  might like to help make them. 5. Ready for more? Get involved - full details on how to do that [can be found here](http://poplus.org/get-involved/).
+
+## FAQs 
+### What is Poplus?
+
+Poplus is an international federation for Collaborative Civic Coding. 
+
+In other words, it brings together people who create civic software, and the organisations or people that need that software.
+
+Its primary aim is to save work for everyone, by sharing digital tools that help people in the civic and democratic areas of life. You can read more on our [About page](http://poplus.org/about/).
+
+
+### How do I join Poplus?
+
+There is no membership process; you become an active member by participating.
+
+But you don’t have to participate immediately! Feel free to join the [Google Group](https://groups.google.com/forum/#!forum/poplus), subscribe to updates, and comment when you have something to say.
+
+### What are some concrete ways to work with Poplus?
+
+There are many ways to get involved. If you are a developer, you can write code, or improve other people’s code.
+
+If you are in need of online tools, you can share your experiences and hopes, and help shape the ones that are made.
+
+If you are neither a coder nor in need of digital tools, but are just an interested person, you are still welcome, and there are many other ways to get involved. For example, you might like to join one of the Poplus sub-committees. Find out more [here](http://poplus.org/get-involved/).
+
+### What are the expectations in working with Poplus?
+
+At the moment there is no minimum requirement. Poplus is still young, and we are in the process of forming it. We will accept all the help that we are offered!
+
+### How do I make contact?
+
+As there is no-one ‘in charge’ of Poplus, most communication is via the [Google Group](https://groups.google.com/forum/#!forum/poplus). This is the place to introduce yourself, ask questions, offer help and feedback, etc etc.
+
+If you have a message that is better suited to one-on-one communication, you should mail hello [at] poplus.org. This email address is accessed by a number of active Poplus members, and one of them will respond.
+
+## Still got questions?
+
+Post them to the [Google Group](https://groups.google.com/forum/#!forum/poplus)!
+


### PR DESCRIPTION
This is a suggested text and placing for a page containing "Things to do first" and FAQs.
Not sure if its creation also automatically includes it in the navigation menu? (or what to do if it doesn't)

The plan is to link to this page from the Google Groups 'sticky post', but I'm also open to suggestion for better placements of this page.
