### PR TITLE
Trello link

### DIFF
--- a/components/suggest
+++ b/components/suggest
@@ -1,0 +1,43 @@
+---
+layout: "inner-page"
+title: Suggest a new Poplus Component
+published: true
+---
+
+##Got an idea for a new Poplus Component?
+
+Whether you have the capability to build it yourself, or you have a great idea but no technical skills, we want to hear your ideas for new Poplus Components.
+
+##Add to our Trello board
+
+Trello is where we collect and prioritise ideas for new Components. You'll see all current ideas on the [Poplus Trello board](https://trello.com/b/5gGF4xrJ/ideas-for-new-poplus-components).
+
+###To add a new idea
+
+* You'll need a Trello account. If you haven't got one, click the big green "sign up for free" button.
+* Read the existing cards to make sure your idea isn't already there (if it is, you can add comments and register a vote to help it rise in priority).
+* If your idea hasn't already been added, click on the card named "Ideas? add them as a comment in this card".
+* Write a comment, describing your idea. One of the team will review it and create a new card for it.
+
+That's it! But if you really want your idea to become a reality, you can do more.
+
+###If you're a coder
+
+You'll probably want to write the code yourself. But it makes sense to discuss it with [the community](https://groups.google.com/forum/#!forum/poplus) first, so that:
+* you can make sure you're not duplicating an idea that's already been developed;
+* people can make suggestions for improvements or features that they'd love to see;
+* you can tap into the knowledge and experience of many other developers;
+* you can talk to others and ensure that your Component will work with different forms of government and within different countries.
+
+
+###If you're not a coder
+
+Then your job will be to inspire the developers in the Poplus community enough that they want to help build your Component!
+
+Make a post on [the Google Group](https://groups.google.com/forum/#!forum/poplus), telling people all about your idea  and asking for feedback - and see if anyone would have an interest in building it. You can also ask people to upvote your idea on the Trello board.
+
+Remember, Poplus members are volunteers, and usually have day-jobs as well as their work here - so there are no guarantees. But great ideas will usually get attention. 
+
+###Questions?
+
+If you have any questions or want to learn more about Poplus, Components, or this process, please join the [Poplus Google Group](https://groups.google.com/forum/#!forum/poplus).


### PR DESCRIPTION
This page was written in response to an action in the Comms committee meeting that the Trello board isn't visible enough.
