### PR TITLE
Add prose.io configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,3 +13,58 @@ sass:
 # @see https://pages.github.com/versions/
 gems:
   - jekyll-redirect-from
+
+prose:
+  # Whitelist allowed directories using .gitignore syntax
+  ignore:
+    - '*'
+    - '!_posts'
+    - '!about'
+    - '!components'
+    - '!es'
+    - '!fr'
+    - '!get-involved'
+    - '!popluscon'
+  siteurl: http://poplus.org
+  media: images
+  relativeLinks: http://poplus.org/links.jsonp
+  metadata:
+    "":
+      - name: layout
+        field:
+          element: hidden
+          value: inner-page
+      - name: title
+        field:
+          element: text
+          label: Title
+          value: ""
+    es:
+      - name: layout
+        field:
+          element: hidden
+          value: inner-page-es
+    fr:
+      - name: layout
+        field:
+          element: hidden
+          value: inner-page-fr
+    _posts:
+      - name: category
+        field:
+          element: hidden
+          value: post
+      - name: layout
+        field:
+          element: hidden
+          value: post
+      - name: title
+        field:
+          element: text
+          label: Title
+          value: ""
+      - name: author
+        field:
+          element: text
+          label: Author
+          value: ""

--- a/links.jsonp
+++ b/links.jsonp
@@ -1,0 +1,10 @@
+---
+---
+callback([
+{% for post in site.posts reversed | sort: title %}
+  {
+    "text": "{{post.title | replace:'"','\"'}}",
+    "href": "{{site.baseurl}}{{post.url}}"
+  } {% unless forloop.last %},{% endunless%}
+{% endfor %}
+])


### PR DESCRIPTION
In order to make it easier for non-devs to update the copy on http://poplus.org I've added some [Prose.io configuration](https://github.com/prose/prose/wiki/Prose-Configuration) to `_config.yml`. This provides a number of benefits when editing the site on http://prose.io
- Most non-markdown files are hidden by default
- Makes it possible to preview changes using the live site's design
- Provides a list of existing posts when inserting a link
- Specifies the media root for inserting existing images or uploading new ones
- Hides metadata such as `layout` that needs to have a specific value
- Provides a friendly interface for setting metadata such as `author`

Here's what the main screen looks like, as you can see only directories containing markdown files are displayed.

![screen shot 2016-01-06 at 09 56 22](https://cloud.githubusercontent.com/assets/22996/12139936/c3538a44-b45b-11e5-8451-3cd6625a74bc.png)

Inserting images:

![screen shot 2016-01-06 at 09 59 23](https://cloud.githubusercontent.com/assets/22996/12140022/7313162a-b45c-11e5-8130-dcc03445c7fb.png)

Previewing a post:

![screen shot 2016-01-06 at 10 00 40](https://cloud.githubusercontent.com/assets/22996/12140032/821c8fac-b45c-11e5-9326-4387c520d3bb.png)
